### PR TITLE
Set Mesos single use slave for test step.

### DIFF
--- a/jobs/test-cd-demo/config.xml
+++ b/jobs/test-cd-demo/config.xml
@@ -71,5 +71,7 @@ exit $exit_status</command>
       </configs>
     </hudson.plugins.parameterizedtrigger.BuildTrigger>
   </publishers>
-  <buildWrappers/>
+  <buildWrappers>
+    <org.jenkinsci.plugins.mesos.MesosSingleUseSlave plugin="mesos@0.11.0"/>
+  </buildWrappers>
 </project>


### PR DESCRIPTION
This fixes the sporadic failures seen when running the test step.
