### PR TITLE
Add extra check for Marathon-lb.

### DIFF
--- a/bin/demo.py
+++ b/bin/demo.py
@@ -105,7 +105,7 @@ def verify(jenkins_url):
 def install_marathon_lb(elb_url):
     log("Checking to see if Marathon-lb is installed.")
     r = requests.get(elb_url)
-    if r.status_code == 503:
+    if r.status_code == 503 and not r.text:
         log ("Couldn't find a Marathon-lb instance running at {}.".format(elb_url))
         log ("Installing Marathon-lb.")
         command = "dcos package install --yes marathon-lb"


### PR DESCRIPTION
Marathon-lb/HAProxy returns text when it provides a 503 response. This is not the case for the ELB, so we can use this plus the 503 status code to distinguish whether or not Marathon-lb has already been installed.
