### PR TITLE
Support [non-EE] open DC/OS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,12 +54,15 @@ node {
 
     // Deploy
     stage 'Deploy'
-    sh "cat marathon.json | jq \".container.docker.image = \\\"mesosphere/cd-demo-app:${gitCommit()}\\\" | .id = \\\"jenkins-deployed-app\\\" | .labels.lastChangedBy = \\\"${gitEmail()}\\\"\" > marathon-rendered.json"
+
     marathon(
         url: 'http://marathon.mesos:8080',
         forceUpdate: false,
         credentialsId: 'dcos-token',
-        filename: 'marathon-rendered.json'
+        filename: 'marathon.json',
+        appid: 'jenkins-deployed-app',
+        docker: "mesosphere/cd-demo-app:${gitCommit()}".toString(),
+        labels: ['lastChangedBy': "${gitEmail()}".toString()]
     )
 
 

--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ When run with the `uninstall` command, it will:
 
     NOTE: You must use the domain name for your cluster; the IP address will fail.
 
-2. You can now run either the pipeline demo or the dynamic slaves demo. To run the pipeline demo, grab the ELB address (`Public Slave`), and make sure to specify the branch to run against:
+2. You can now run either the pipeline demo or the dynamic slaves demo. To run the pipeline demo, you will also need to specify the ELB address (`Public Slave`):
 
     ```
-    python bin/demo.py pipeline --branch=my-demo-branch --password=$PASSWORD http://my.elb/ http://my.dcos.cluster/
+    python bin/demo.py pipeline  --password=$PASSWORD http://my.elb/ http://my.dcos.cluster/
     ```
 
 3. The script will first install Marathon-lb if it looks like it isn't available. It will also update the `marathon.json` in the branch you specified to include the ELB hostname so that Marathon-lb can route to it.
@@ -114,15 +114,15 @@ By default, this script assumes you will be pushing to the [mesosphere/cd-demo-a
 3. Run the pipeline demo, passing in the credentials:
 
     ```
-    python bin/demo.py pipeline --branch=my-demo-branch --org=myorg --username=myuser --password=$PASSWORD http://my.elb/ http://my.dcos.cluster/
+    python bin/demo.py pipeline --org=myorg --username=myuser --password=$PASSWORD http://my.elb/ http://my.dcos.cluster/
     ```
 
 ### Build on Commit
 
-1. Run the demo to completion with the `--branch` parameter to monitor your branch. The pipeline will continue to monitor your branch after the script finishes:
+1. Run the demo to completion. The pipeline will continue to monitor your branch after the script finishes:
 
     ```
-    python bin/demo.py pipeline --branch=my-demo-branch --password=$PASSWORD http://my.elb/ http://my.dcos.cluster/
+    python bin/demo.py pipeline --password=$PASSWORD http://my.elb/ http://my.dcos.cluster/
     ```
 
 3. Create a new blog post with today's date, open it up in your text editor and make whatever changes you'd like to:
@@ -164,6 +164,14 @@ To demonstrate how you can install multiple Jenkins instances side by side on DC
     bin/demo.py uninstall --name=jenkins-1 http://my.dcos.cluster/
     bin/demo.py uninstall --name=jenkins-2 http://my.dcos.cluster/
     ```
+
+### Authentication
+
+The script will check to see if your current machine has a valid `dcos_acs_token` set. If it doesn't:
+
+1. it attempts to authenticate using the default username and password for an Enterprise DC/OS cluster. You can override these using the `--dcos-username` and `--dcos-password` arguments.
+
+2. if this fails, it will attempt to use the `--dcos-oauth-token` arguments to authenticate against an Open DC/OS cluster.
 
 ## TODO
 

--- a/bin/demo.py
+++ b/bin/demo.py
@@ -10,7 +10,6 @@ Usage:
 
 Options:
     --name <name>               Jenkins instance name to use [default: jenkins]
-    --branch <branch>           Git branch for continuous delivery demo
     --org <org>                 Docker Hub organisation [default: mesosphere]
     --username <user>           Docker Hub username [default: cddemo]
     --password <pass>           Docker Hub password
@@ -160,6 +159,10 @@ def verify_marathon_lb(marathon_lb_url):
 def strip_to_hostname(url):
     parsed_url = urlparse(url)
     return parsed_url.netloc
+
+def get_branch():
+    branch = subprocess.check_output(['git','rev-parse', '--abbrev-ref', 'HEAD'])
+    return str(branch, 'utf-8').strip()
 
 def update_and_push_marathon_json(elb_url, branch):
     elb_hostname = strip_to_hostname(elb_url)
@@ -311,7 +314,7 @@ if __name__ == "__main__":
                 log("couldn't find Jenkins running at '{}'".format(jenkins_url))
                 install_jenkins(jenkins_name, jenkins_url)
         elif arguments['pipeline']:
-            branch = arguments['--branch'].lower()
+            branch = get_branch()
             if branch == 'master':
                 log_and_exit("!! cannot run demo against the master branch.")
             org = arguments['--org']

--- a/bin/demo.py
+++ b/bin/demo.py
@@ -43,6 +43,9 @@ from urllib.parse import urlparse
 
 from shakedown import *
 
+jenkins_version = "2.0.0-2.7.2"
+marathon_lb_version="1.3.5"
+
 def log(message):
     print("[demo]: {}".format(message))
 
@@ -115,7 +118,7 @@ def install_jenkins(jenkins_name, jenkins_url):
         package_config = options_file.read().replace("JENKINS_NAME", jenkins_name)
     with open("jenkins_config.json", "w") as options_file:
         options_file.write(package_config)
-    install_package('jenkins', None, jenkins_name, "jenkins_config.json")
+    install_package('jenkins', jenkins_version, jenkins_name, "jenkins_config.json")
     os.remove("jenkins_config.json")
     assert package_installed('jenkins', jenkins_name), log_and_exit('!! package failed to install')
     log("waiting for Jenkins service to come up at '{}'".format(jenkins_url))
@@ -140,9 +143,9 @@ def install_marathon_lb(marathon_lb_url):
         try:
             authenticate_with_username() # test to see if we're on Enterprise DC/OS
             install_marathon_lb_secret(marathon_lb_url)
-            install_package('marathon-lb', None, None, "conf/marathon-lb.json")
+            install_package('marathon-lb', marathon_lb_version, None, None, "conf/marathon-lb.json")
         except:
-            install_package('marathon-lb')
+            install_package('marathon-lb', marathon_lb_version)
     else:
         log("marathon-lb is already installed")
 

--- a/bin/demo.py
+++ b/bin/demo.py
@@ -185,11 +185,11 @@ def update_and_push_marathon_json(elb_url, branch):
     with open("marathon.json", "w") as options_file:
         options_file.write(app_config)
     if call(['git', 'add', 'marathon.json']) != 0:
-        log_and_exit("!! failed to add marathon.json to git repo")
+        log("!! failed to add marathon.json to git repo")
     if call(['git', 'commit', 'marathon.json', '-m', 'Update marathon.json with ELB hostname']) != 0:
-        log_and_exit("!! failed to commit updated marathon.json")
+        log("!! failed to commit updated marathon.json")
     if call(['git', 'push', 'origin', branch]) != 0:
-        log_and_exit("!! failed to push updated marathon.json")
+        log("!! failed to push updated marathon.json")
     log("updated marathon.json with ELB hostname '{}'".format(elb_hostname))
 
 def trigger_build(jenkins_url, job_name, parameter_string = None):

--- a/bin/demo.py
+++ b/bin/demo.py
@@ -301,8 +301,12 @@ def cleanup_dynamic_slaves_jobs(jenkins_url, builds):
         job_name = "demo-job-{0:02d}".format(i)
         delete_job(jenkins_url, job_name)
 
+def cleanup_deployed_app():
+    dcos.marathon.create_client().remove_app('jenkins-deployed-app', force=True)
+
 def cleanup(jenkins_url, builds):
     cleanup_pipeline_jobs(jenkins_url)
+    cleanup_deployed_app()
     cleanup_dynamic_slaves_jobs(jenkins_url, builds)
 
 def uninstall(jenkins_name):

--- a/bin/demo.py
+++ b/bin/demo.py
@@ -96,14 +96,18 @@ def authenticate_with_oauth(dcos_url):
 def authenticate_with_username():
     dcos_username = arguments['--dcos-username']
     dcos_password = arguments['--dcos-password']
-    token = shakedown.authenticate(dcos_username, dcos_password)
-    dcos.config.set_val('core.dcos_acs_token', token)
+    try:
+        token = shakedown.authenticate(dcos_username, dcos_password)
+        dcos.config.set_val('core.dcos_acs_token', token)
+    except:
+        log_and_exit('!! DC/OS authentication failed; ' +
+                'invalid --dcos-username and --dcos-password provided')
+
 
 def check_and_set_token(dcos_url):
     if needs_authentication():
-        dcos_oauth_token = arguments['--dcos-oauth-token']
-        if dcos_oauth_token:
-            authenticate_with_oauth(dcos_url, dcos_oauth_token)
+        if '--dcos-oauth-token' in arguments:
+            authenticate_with_oauth(dcos_url)
         else:
             authenticate_with_username()
         if needs_authentication():


### PR DESCRIPTION
- Work against open DC/OS. User can specify the DC/OS ACS token manually if they wish using `--dcos-oauth-token`. This is the token that is provided after a user logs in using an OAuth provider.
- Added an authentication check (if the user has already logged in on their machine).
- Removed the branch parameter (just assume the user is running this from the correct branch already).
- Check to see if Marathon-lb is already installed before attemping to install it.
