### PR TITLE
Pin shakedown to `1.4.4`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-dcos-shakedown
+dcos-shakedown==1.4.4
 docopt


### PR DESCRIPTION
`1.4.5` bumps `dcoscli` to `0.5.3`, which causes authentication problems
with this demo.