### PR TITLE
1.10 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,17 +47,29 @@ Tip: If Python 3 is not the default on your system, you may need to specifically
     git clone https://github.com/mesosphere/cd-demo.git
     ```
 
-2. Create a branch from the latest stable tag, this is mandatory:
+2. Check out the latest stable tag, depending on DC/OS cluster version you're running against:
 
+    DC/OS 1.10+:
+    ```
+    git checkout v1.8.7-2.7.2
+    ```
+
+    DC/OS 1.9 and below:
     ```
     git checkout v1.8.6-2.7.2
+    ```
+
+
+3. Create a branch from the latest stable tag, this is mandatory:
+
+    ```
     git checkout -b my-demo-branch
     git push origin my-demo-branch
     ```
 
-3. Ensure you have a DC/OS cluster available. 1 node will work but more than 1 node is preferable to demonstrate build parallelism.
+4. Ensure you have a DC/OS cluster available. 1 node will work but more than 1 node is preferable to demonstrate build parallelism.
 
-4. Export the demo Docker Hub password (NOT the DC/OS cluster password) to an environment variable. You will need to replace the password here with the password for the `cddemo` user with permission to push to `mesosphere/cd-demo-app` (or your own repo, if you override the `--org` and `--username` flags later):
+5. Export the demo Docker Hub password (NOT the DC/OS cluster password) to an environment variable. You will need to replace the password here with the password for the `cddemo` user with permission to push to `mesosphere/cd-demo-app` (or your own repo, if you override the `--org` and `--username` flags later):
 
     ```
     export PASSWORD=mypass123

--- a/bin/demo.py
+++ b/bin/demo.py
@@ -44,7 +44,7 @@ from urllib.parse import urlparse
 
 from shakedown import *
 
-jenkins_version = "2.0.0-2.7.2"
+jenkins_version = "3.2.2-2.60.2"
 marathon_lb_version="1.3.5"
 
 def log(message):

--- a/bin/demo.py
+++ b/bin/demo.py
@@ -116,8 +116,17 @@ def check_and_set_token(dcos_url):
                 'did you provide --dcos-username and --dcos-password or --dcos-oauth-token?')
 
 def config_dcos_cli(dcos_url):
-    dcos.config.set_val('core.dcos_url', dcos_url)
-    dcos.config.set_val('core.ssl_verify', 'False')
+    with dcos.cluster.setup_directory() as temp_path:
+        dcos.cluster.set_attached(temp_path)
+        dcos.config.set_val('core.dcos_url', dcos_url)
+        dcos.config.set_val('core.ssl_verify', 'False')
+
+        try:
+            shakedown.dcos_leader()
+        except:
+            check_and_set_token(dcos_url)
+            dcos.cluster.setup_cluster_config(dcos_url, temp_path, False)
+
 
 def install_jenkins(jenkins_name, jenkins_url):
     log("installing Jenkins with name '{}'".format(jenkins_name))
@@ -381,7 +390,6 @@ if __name__ == "__main__":
         jenkins_version = None
 
     config_dcos_cli(dcos_url)
-    check_and_set_token(dcos_url)
 
     try:
         if arguments['install']:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-dcos-shakedown==1.4.4
+dcos-shakedown==1.4.5
 docopt


### PR DESCRIPTION
I'll need to add a new `1.8.7-2.7.2` tag pointing to `master` once this is merged.  `1.8.6-2.7.2` should continue to function for 1.9 clusters and below (`dcoscli 0.4.16`).