### PR TITLE
Add staging script for cd-demo

### DIFF
--- a/Jenkinsfile.demo
+++ b/Jenkinsfile.demo
@@ -13,9 +13,9 @@ def gitEmail() {
 }
 
 def ipAddress() {
-    sh "docker inspect test-container-${env.BUILD_NUMBER} | jq -r '.[0].NetworkSettings.IPAddress' > IP_ADDRESS-${env.BUILD_NUMBER}"
-    def ipAddress = readFile("IP_ADDRESS-${env.BUILD_NUMBER}").trim()
-    sh "rm -f IP_ADDRESS-${env.BUILD_NUMBER}"
+    sh "docker inspect test-container | jq -r '.[0].NetworkSettings.IPAddress' > IP_ADDRESS"
+    def ipAddress = readFile("IP_ADDRESS").trim()
+    sh "rm -f IP_ADDRESS"
     return ipAddress
 }
 
@@ -33,7 +33,7 @@ node {
 
     // Test Docker image
     stage 'Test'
-    sh "docker run -d --name=test-container-${env.BUILD_NUMBER} mesosphere/cd-demo-app:${gitCommit()} jekyll serve"
+    sh "docker run -d --name=test-container mesosphere/cd-demo-app:${gitCommit()} jekyll serve"
     sh "docker run mesosphere/linkchecker linkchecker --no-warnings http://${ipAddress()}:4000/"
 
 
@@ -70,4 +70,5 @@ node {
     stage 'Clean'
     sh "docker kill \$(docker ps -q)"
     sh "docker rm \$(docker ps -a -q)"
+    sh "docker rmi \$(docker images -q)"
 }

--- a/Jenkinsfile.demo
+++ b/Jenkinsfile.demo
@@ -68,6 +68,6 @@ node {
 
     // Clean up
     stage 'Clean'
-    sh "docker kill $(docker ps -q)"
-    sh "docker rm $(docker ps -a -q)"
+    sh "docker kill \$(docker ps -q)"
+    sh "docker rm \$(docker ps -a -q)"
 }

--- a/Jenkinsfile.demo
+++ b/Jenkinsfile.demo
@@ -68,6 +68,6 @@ node {
 
     // Clean up
     stage 'Clean'
-    sh "docker kill test-container-${env.BUILD_NUMBER}"
-    sh "docker rm test-container-${env.BUILD_NUMBER}"
+    sh "docker kill $(docker ps -q)"
+    sh "docker rm $(docker ps -a -q)"
 }

--- a/Jenkinsfile.demo
+++ b/Jenkinsfile.demo
@@ -13,14 +13,15 @@ def gitEmail() {
 }
 
 def ipAddress() {
-    sh "docker inspect test-container | jq -r '.[0].NetworkSettings.IPAddress' > IP_ADDRESS"
-    def ipAddress = readFile("IP_ADDRESS").trim()
-    sh "rm -f IP_ADDRESS"
+    sh "docker inspect test-container-${env.BUILD_NUMBER} | jq -r '.[0].NetworkSettings.IPAddress' > IP_ADDRESS-${env.BUILD_NUMBER}"
+    sh "docker inspect test-container-${env.BUILD_NUMBER} | jq -r '.[0].NetworkSettings'"
+    def ipAddress = readFile("IP_ADDRESS-${env.BUILD_NUMBER}").trim()
+    sh "rm -f IP_ADDRESS-${env.BUILD_NUMBER}"
     return ipAddress
 }
 
-
-node {
+try {
+ node {
     // Checkout source code from Git
     stage 'Checkout'
     checkout scm
@@ -33,7 +34,7 @@ node {
 
     // Test Docker image
     stage 'Test'
-    sh "docker run -d --name=test-container mesosphere/cd-demo-app:${gitCommit()} jekyll serve"
+    sh "docker run -d --name=test-container-${env.BUILD_NUMBER} mesosphere/cd-demo-app:${gitCommit()} jekyll serve"    
     sh "docker run mesosphere/linkchecker linkchecker --no-warnings http://${ipAddress()}:4000/"
 
 
@@ -64,11 +65,27 @@ node {
         docker: "mesosphere/cd-demo-app:${gitCommit()}".toString(),
         labels: [[name: 'lastChangedBy', value: "${gitEmail()}".toString()]]
     )
+ }
+} catch (Exception e) {
+    println 'Build Failed'
+    currentBuild.result = 'FAILURE'
+    stage 'Publish'
+    println 'Skipped'
+    stage 'Deploy'
+    println 'Skipped'
+}
 
 
+
+try {
+ node {
     // Clean up
     stage 'Clean'
-    sh "docker kill \$(docker ps -q)"
-    sh "docker rm \$(docker ps -a -q)"
-    sh "docker rmi \$(docker images -q)"
-}
+    sh "docker ps"
+    sh "docker kill test-container-${env.BUILD_NUMBER}"
+    sh "docker rm test-container-${env.BUILD_NUMBER}"
+ }
+} catch (Exception e) {
+    println 'Cleanup failed'
+    currentBuild.result = 'FAILURE'
+} 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,30 @@ The script will check to see if your current machine has a valid `dcos_acs_token
 
 2. if this fails, it will attempt to use the `--dcos-oauth-token` arguments to authenticate against an Open DC/OS cluster.
 
+## Orchestration Script for Demos
+
+If you would prefer to have an all-in-one demo experience, we now have a stage_cd_demo.sh script that will follow the default demo flow.
+
+To run, the syntax is:
+
+```
+bash ./stage_cd_demo.sh <url-to-master> <url-of-public-elb>
+```
+
+This script will prompt you to walk through the demo, in the following order:
+
+- Stage your local environment (install python dependencies, configure dcos cli, prompt you for the cd-demo docker password, install jenkins)
+- Kick off the pipeline demo (install and configure marathon-lb, kick off initial pipeline demo build)
+- Create a new post, commit to your branch, and trigger a pipeline rebuild by pushing the change to githhub
+- Kick off dynamic load demonstration (launch 50 nodes in parallel, including a jenkins config change to speed up the time to launch new build executors)
+- Clean up your github branch and cluster after the fact so you're ready for another runthrough
+
+At each stage above, the script will pause and you will need to press ENTER to continue.
+
+If you would prefer not to get prompted for the demo docker password, you can create a ```password.txt``` file in the repo root directory (e.g. ~/repos/cd-demo/password.txt) with the password, which will override the manual prompt.
+
+The password file will NOT be committed to your branch.
+
 ## TODO
 
 + This script is currently untested on Windows.

--- a/conf/jenkins.json
+++ b/conf/jenkins.json
@@ -1,5 +1,8 @@
 {
   "service": {
     "name": "JENKINS_NAME"
+  },
+  "advanced": {
+    "jvm-opts": "-Xms1024m -Xmx1024m -Dhudson.slaves.NodeProvisioner.MARGIN=50 -Dhudson.slaves.NodeProvisioner.MARGIN0=0.85"
   }
 }

--- a/stage_cd_demo.sh
+++ b/stage_cd_demo.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# Script for setting up the CI/CD demo in DC/OS
+#
+
+# Requirements:
+#   - DC/OS cluster with 1 public slave and 5 private slaves with
+#       or without superuser set
+#   - DCOS CLI installed on localhost
+#   - DCOS_EE set to true or false
+#   - DCOS_URL set to DCOS master URL
+#
+# If no user credentials are supplied, the following will be used:
+#   Enterprise:
+#     - AWS default bootstrapuser/deleteme
+#     - Override with DCOS_USER & DCOS_PW
+#   OSS:
+#     - The token hard-coded below for mesosphere.user@gmail.com
+#         password: unicornsarereal
+#     - Override with DCOS_AUTH_TOKEN
+set -o errexit
+
+if [ -z ${DCOS_EE+x} ]; then DCOS_EE=true; fi
+if [ -z ${DCOS_URL+x} ]; then
+#strip http(s) from Master IP url
+mip_clean=${1#*//}
+#strip trailing slash from Master IP url
+DCOS_URL=https://${mip_clean%/}/
+fi
+
+if [ -z ${DCOS_PUB_ELB+x} ]; then
+# strip http(s) from ELB url
+elb_clean=${2#*//}
+# strip trailing slash from ELB url
+DCOS_PUB_ELB=https://${elb_clean%/}/
+fi
+
+#Run CI Script in infrastructure mode
+for i in `dcos cluster list | awk ' FNR > 1 { print $1 }' | sed 's/\*//'`; do dcos cluster remove $i; done
+
+DCOS_AUTH_TOKEN=${DCOS_AUTH_TOKEN:=$ci_auth_token}
+DCOS_USER=${DCOS_USER:='bootstrapuser'}
+DCOS_PW=${DCOS_PW:='deleteme'}
+
+log_msg() {
+    echo `date -u +'%D %T'`: $1
+}
+
+cmd_eval() {
+        log_msg "Executing: $1"
+        eval $1
+}
+
+
+ee_login() {
+cat <<EOF | expect -
+spawn dcos cluster setup "$DCOS_URL" --no-check
+expect "username:"
+send "$DCOS_USER\n"
+expect "password:"
+send "$DCOS_PW\n"
+expect eof
+EOF
+}
+
+sudo pip3 install -r requirements.txt
+
+cmd_eval ee_login
+dcos package install --yes dcos-enterprise-cli
+
+echo $DCOS_URL
+
+if [ -e "password.txt" ]
+then
+  docker_password=`cat password.txt`
+fi
+
+if [ -z "$docker_password" ]
+then
+        echo -n "Enter docker repo password and press [ENTER]: "
+        read -s docker_password
+fi
+
+python3 bin/demo.py install $DCOS_URL
+
+read -p "SETUP Complete, Press Any Key to Continue"
+
+python3 bin/demo.py pipeline  --password=$docker_password $DCOS_PUB_ELB $DCOS_URL
+counter=1
+read -p "Press any key to commit a new post"
+
+cp site/_posts/2016-02-25-welcome-to-cd-demo.markdown site/_posts/`date +'%Y-%m-%d'`-new-post.markdown
+git add site/_posts/*
+git commit -m 'New Post'
+git push
+counter=$((counter+1))
+
+read -p "PIPELINE Demo complete, Press Any Key to Continue"
+
+python3 bin/demo.py dynamic-agents $DCOS_URL
+
+read -p "Dynamic Agents Demo complete, Press Any Key to Continue"
+
+python3 bin/demo.py uninstall $DCOS_URL
+dcos package uninstall --yes marathon-lb
+git reset --hard HEAD~$counter
+git push -f
+dcos security secrets delete marathon-lb


### PR DESCRIPTION
To make it easier for the field to execute the CD demo for customers, I created an orchestration script to step through the demo directly. In the meantime, I noticed a couple of other issues that I patched, mainly:
1) If you committed code to the pipeline demo the rebuild would fail on the “test” step because the link checker wouldn’t be running where it’s expected
2) build executors were taking a LONG time to launch for the dynamic load demo (4+ minutes) - I updated the jenkins.json file to speed that up